### PR TITLE
Update Travis config to prevent rubocop from running against Ruby 2.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,23 @@
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: true
+
 Layout/LineLength:
   Max: 120
+
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: true
+
+Lint/MixedRegexpCaptureTypes:
+  Enabled: true
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
 
 Metrics/BlockLength:
   Exclude:
@@ -13,3 +31,24 @@ Style/ClassVars:
 
 Style/DoubleNegation:
   Enabled: false
+
+Style/ExponentialNotation:
+  Enabled: true
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
+
+Style/RedundantRegexpCharacterClass:
+  Enabled: true
+
+Style/RedundantRegexpEscape:
+  Enabled: true
+
+Style/SlicingWithRange:
+  Enabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
 
 install:
   - bundle install --jobs=3 --retry=3
-  - gem install rubocop
+  - ruby --version | grep '^ruby 2\.3\.' > /dev/null || gem install rubocop
 
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
@@ -25,7 +25,7 @@ before_script:
   - ./cc-test-reporter before-build
 
 script:
-  - rubocop
+  - ruby --version | grep '^ruby 2\.3\.' > /dev/null || rubocop
   - bundle exec rspec
 
 after_script:


### PR DESCRIPTION
Also updated Rubocop config to support 0.85 spec cops