### PR TITLE
PERF: Eliminate dependency on mime-types gem

### DIFF
--- a/henkei.gemspec
+++ b/henkei.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'json', '>= 1.8', '< 3'
-  spec.add_runtime_dependency 'mime-types', '>= 1.23', '< 4'
+  spec.add_runtime_dependency('mini_mime', '>= 0.1.1')
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rails', '~> 5.0'

--- a/henkei.gemspec
+++ b/henkei.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'json', '>= 1.8', '< 3'
-  spec.add_runtime_dependency('mini_mime', '>= 0.1.1')
+  spec.add_runtime_dependency 'mini_mime', '>= 0.1.1'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rails', '~> 5.0'

--- a/lib/henkei.rb
+++ b/lib/henkei.rb
@@ -33,7 +33,6 @@ class Henkei # rubocop:disable Metrics/ClassLength
   @@server_pid = nil
 
   def self.mimetype(content_type)
-    Henkei.configure # ensure there is a configuration
     if Henkei.configuration.mime_library == 'mime/types' && defined?(MIME::Types)
       warn '[DEPRECATION] `mime/types` is deprecated. Please use `mini_mime` instead.'\
         ' Use Henkei.configure and assign "mini_mime" to `mime_library`.'

--- a/lib/henkei/configuration.rb
+++ b/lib/henkei/configuration.rb
@@ -2,13 +2,12 @@
 
 # Henkei monkey patch for configuration support
 class Henkei
-  class << self
-    attr_accessor :configuration
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
 
-    def configure
-      self.configuration ||= Configuration.new
-      yield(configuration) if block_given?
-    end
+  def self.configure
+    yield(configuration)
   end
 
   # Handle Henkei configuration

--- a/lib/henkei/configuration.rb
+++ b/lib/henkei/configuration.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Henkei monkey patch for configuration support
 class Henkei
   class << self
     attr_accessor :configuration

--- a/lib/henkei/configuration.rb
+++ b/lib/henkei/configuration.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Henkei
+  class << self
+    attr_accessor :configuration
+
+    def configure
+      self.configuration ||= Configuration.new
+      yield(configuration) if block_given?
+    end
+  end
+
+  # Handle Henkei configuration
+  class Configuration
+    attr_accessor :mime_library
+
+    def initialize
+      @mime_library = 'mime/types'
+    end
+  end
+end


### PR DESCRIPTION
**Inspired by: https://github.com/rest-client/rest-client/pull/644**

Eliminate the dependency on `mime-types` which is a memory hog.

The gem `mini_mime` (https://github.com/discourse/mini_mime) was created in replacement. It uses the exact same database as the full fledged mime types and is capable of only loading stuff on demand with a practical, safe and bound in-memory cache.

Allocated memory by gem (derailed benchmarks):

| gem | memory |
|---|---|
| mime-types | 6256476 | 
| mini_mime | 7606 |
