### PR TITLE
Update Apache Tika to v2.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,6 @@ before_install:
 install:
   - bundle install --jobs=3 --retry=3
   - gem install rubocop
-  - export TESSERACT_VERSION=4.1.0-1
-  - export TESSERACT_INSTALL=$HOME/.tesseract
-  - export TESSERACT_PKG=$TESSERACT_INSTALL/lib/pkgconfig
-  - export LD_LIBRARY_PATH=$TESSERACT_INSTALL/lib:$LD_LIBRARY_PATH
-  - export PKG_CONFIG_PATH=$TESSERACT_PKG:$PKG_CONFIG_PATH
-  - wget -O - https://github.com/nijel/tesseract-ocr-build/releases/download/$TESSERACT_VERSION/tesseract.tar.xz | tar -C $HOME -xJf -
 
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,12 @@ before_install:
 install:
   - bundle install --jobs=3 --retry=3
   - gem install rubocop
+  - export TESSERACT_VERSION=4.1.0-1
+  - export TESSERACT_INSTALL=$HOME/.tesseract
+  - export TESSERACT_PKG=$TESSERACT_INSTALL/lib/pkgconfig
+  - export LD_LIBRARY_PATH=$TESSERACT_INSTALL/lib:$LD_LIBRARY_PATH
+  - export PKG_CONFIG_PATH=$TESSERACT_PKG:$PKG_CONFIG_PATH
+  - wget -O - https://github.com/nijel/tesseract-ocr-build/releases/download/$TESSERACT_VERSION/tesseract.tar.xz | tar -C $HOME -xJf -
 
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ Here are some of the formats supported:
 For the complete list of supported formats, please visit the Apache Tika
 [Supported Document Formats](http://tika.apache.org/0.9/formats.html) page.
 
+## Upgrading from v1.x to v2.x
+
+Apache Tika v2.x brings with it some changes. One key change is that the Tika client and server applications have
+been split up. To keep the gem size down Henkei will only include the client app. That is to say, each time you
+call to Henkei, a new Java process will be started, run your command, then terminate.
+
+Another change is the metadata keys. A lot of duplicate keys have been removed in favour of a more standards
+based approach. A list of the old vs new key names can be found [here](https://cwiki.apache.org/confluence/display/TIKA/Migrating+to+Tika+2.0.0#MigratingtoTika2.0.0-Metadata) 
+
 ## Usage
 
 Text, metadata and MIME type information can be extracted by calling `Henkei.read` directly:
@@ -67,6 +76,20 @@ post '/:name/:filename' do
   henkei = Henkei.new params[:data][:tempfile]
   henkei.text
 end
+```
+
+### Reading text from inside images (OCR)
+
+You can enable OCR by specifying the optional `include_ocr: true` when calling to the `text` or `html` instance methods,
+as well as the `read` class method. Note that Tika does indicate this will greatly increase processing time.
+
+```ruby
+henkei = Henkei.new 'sample.pages'
+text_with_ocr = henkei.text(include_ocr: true)
+html_with_ocr = henkei.html(include_ocr: true)
+
+data = File.read 'sample.pages'
+text_with_ocr = Henkei.read :text, data, include_ocr: true
 ```
 
 ### Reading metadata

--- a/henkei.gemspec
+++ b/henkei.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'mini_mime', '>= 0.1.1', '< 2'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'nokogiri', '~> 1.12'
   spec.add_development_dependency 'rails', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'rspec', '~> 3.7'

--- a/jar/tika-config-without-ocr.xml
+++ b/jar/tika-config-without-ocr.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<properties>
+  <service-loader initializableProblemHandler="ignore"/>
+  <parsers>
+    <parser class="org.apache.tika.parser.DefaultParser">
+      <parser-exclude class="org.apache.tika.parser.ocr.TesseractOCRParser"/>
+    </parser>
+  </parsers>
+</properties>

--- a/jar/tika-config.xml
+++ b/jar/tika-config.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <properties>
   <service-loader initializableProblemHandler="ignore"/>
 </properties>

--- a/lib/henkei/version.rb
+++ b/lib/henkei/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Henkei
-  VERSION = '1.27.1'
+  VERSION = '2.2.0.1'
 end

--- a/spec/henkei_spec.rb
+++ b/spec/henkei_spec.rb
@@ -54,18 +54,20 @@ describe Henkei do
         expect(text).to eq ''
       end
 
-      context 'when `include_ocr` is enabled' do
-        it 'returns parsed plain text in the image' do
-          text = Henkei.read :text, data, include_ocr: true
+      unless travis_ci?
+        context 'when `include_ocr` is enabled' do
+          it 'returns parsed plain text in the image' do
+            text = Henkei.read :text, data, include_ocr: true
 
-          expect(text).to include <<~TEXT
-            West Side
-  
-            Sea Island
-            PP
-  
-            Richmond
-          TEXT
+            expect(text).to include <<~TEXT
+              West Side
+    
+              Sea Island
+              PP
+    
+              Richmond
+            TEXT
+          end
         end
       end
     end
@@ -176,24 +178,26 @@ describe Henkei do
         expect(henkei.mimetype.content_type).to eq 'image/png'
       end
 
-      context 'when `include_ocr` is enabled' do
-        it '#text returns plain text of parsed text in the image' do
-          expect(henkei.text(include_ocr: true)).to include <<~TEXT
-            West Side
-  
-            Sea Island
-            PP
-  
-            Richmond
-          TEXT
-        end
+      unless travis_ci?
+        context 'when `include_ocr` is enabled' do
+          it '#text returns plain text of parsed text in the image' do
+            expect(henkei.text(include_ocr: true)).to include <<~TEXT
+              West Side
+    
+              Sea Island
+              PP
+    
+              Richmond
+            TEXT
+          end
 
-        it '#html returns HTML of parsed text in the image' do
-          expect(henkei.html(include_ocr: true)).to include '<meta name="tiff:ImageWidth" content="792"/>'
+          it '#html returns HTML of parsed text in the image' do
+            expect(henkei.html(include_ocr: true)).to include '<meta name="tiff:ImageWidth" content="792"/>'
 
-          html_body = Nokogiri::HTML(henkei.html(include_ocr: true)).at_xpath('//body')
-          ['Anmore', 'Coquitlam', 'West Side', 'Sea Island', 'Richmond', 'Steveston'].each do |location|
-            expect(html_body.text).to include location
+            html_body = Nokogiri::HTML(henkei.html(include_ocr: true)).at_xpath('//body')
+            ['Anmore', 'Coquitlam', 'West Side', 'Sea Island', 'Richmond', 'Steveston'].each do |location|
+              expect(html_body.text).to include location
+            end
           end
         end
       end
@@ -236,5 +240,9 @@ describe Henkei do
     specify '#metadata reads metadata' do
       expect(henkei.metadata['Content-Type']).to eq 'application/pdf'
     end
+  end
+
+  def travis_ci?
+    ENV['CI'] == 'true' && ENV['TRAVIS'] == 'true'
   end
 end

--- a/spec/henkei_spec.rb
+++ b/spec/henkei_spec.rb
@@ -7,6 +7,10 @@ require 'nokogiri'
 # Some of the tests have been known to fail in weird and wonderful ways when `rails` is included
 require 'rails' if ENV['INCLUDE_RAILS'] == 'true'
 
+def travis_ci?
+  ENV['CI'] == 'true' && ENV['TRAVIS'] == 'true'
+end
+
 describe Henkei do
   let(:data) { File.read 'spec/samples/sample.docx' }
 
@@ -240,9 +244,5 @@ describe Henkei do
     specify '#metadata reads metadata' do
       expect(henkei.metadata['Content-Type']).to eq 'application/pdf'
     end
-  end
-
-  def travis_ci?
-    ENV['CI'] == 'true' && ENV['TRAVIS'] == 'true'
   end
 end

--- a/spec/henkei_spec.rb
+++ b/spec/henkei_spec.rb
@@ -2,6 +2,7 @@
 
 require 'helper'
 require 'henkei'
+require 'nokogiri'
 
 # Some of the tests have been known to fail in weird and wonderful ways when `rails` is included
 require 'rails' if ENV['INCLUDE_RAILS'] == 'true'
@@ -51,6 +52,21 @@ describe Henkei do
         text = Henkei.read :text, data
 
         expect(text).to eq ''
+      end
+
+      context 'when `include_ocr` is enabled' do
+        it 'returns parsed plain text in the image' do
+          text = Henkei.read :text, data, include_ocr: true
+
+          expect(text).to include <<~TEXT
+            West Side
+  
+            Sea Island
+            PP
+  
+            Richmond
+          TEXT
+        end
       end
     end
   end
@@ -115,6 +131,7 @@ describe Henkei do
 
   describe '.creation_date' do
     let(:henkei) { Henkei.new 'spec/samples/sample.pages' }
+
     it 'should return Time' do
       expect(henkei.creation_date).to be_a Time
     end
@@ -158,6 +175,28 @@ describe Henkei do
       it '#mimetype returns `image/png`' do
         expect(henkei.mimetype.content_type).to eq 'image/png'
       end
+
+      context 'when `include_ocr` is enabled' do
+        it '#text returns plain text of parsed text in the image' do
+          expect(henkei.text(include_ocr: true)).to include <<~TEXT
+            West Side
+  
+            Sea Island
+            PP
+  
+            Richmond
+          TEXT
+        end
+
+        it '#html returns HTML of parsed text in the image' do
+          expect(henkei.html(include_ocr: true)).to include '<meta name="tiff:ImageWidth" content="792"/>'
+
+          html_body = Nokogiri::HTML(henkei.html(include_ocr: true)).at_xpath('//body')
+          ['Anmore', 'Coquitlam', 'West Side', 'Sea Island', 'Richmond', 'Steveston'].each do |location|
+            expect(html_body.text).to include location
+          end
+        end
+      end
     end
   end
 
@@ -196,42 +235,6 @@ describe Henkei do
 
     specify '#metadata reads metadata' do
       expect(henkei.metadata['Content-Type']).to eq 'application/pdf'
-    end
-  end
-
-  context 'working as server mode' do
-    specify '#starts and kills server' do
-      begin
-        Henkei.server(:text)
-        expect(Henkei.class_variable_get(:@@server_pid)).not_to be_nil
-        expect(Henkei.class_variable_get(:@@server_port)).not_to be_nil
-
-        s = TCPSocket.new('localhost', Henkei.class_variable_get(:@@server_port))
-        expect(s).to be_a TCPSocket
-        s.close
-      ensure
-        port = Henkei.class_variable_get(:@@server_port)
-        Henkei.kill_server!
-        sleep 2
-        expect { TCPSocket.new('localhost', port) }.to raise_error Errno::ECONNREFUSED
-      end
-    end
-
-    specify '#runs samples through server mode' do
-      begin
-        Henkei.server(:text)
-        expect(Henkei.new('spec/samples/sample.pages').text).to(
-          include 'The quick brown fox jumped over the lazy cat.'
-        )
-        expect(Henkei.new('spec/samples/sample filename with spaces.pages').text).to(
-          include 'The quick brown fox jumped over the lazy cat.'
-        )
-        expect(Henkei.new('spec/samples/sample.docx').text).to(
-          include 'The quick brown fox jumped over the lazy cat.'
-        )
-      ensure
-        Henkei.kill_server!
-      end
     end
   end
 end


### PR DESCRIPTION
Apache Tika v2.x brings with it some changes. One key change is that the Tika client and server applications have
been split up. To keep the gem size down Henkei will only include the client app. That is to say, each time you
call to Henkei, a new Java process will be started, run your command, then terminate.

Another change is the metadata keys. A lot of duplicate keys have been removed in favour of a more standards
based approach. A list of the old vs new key names can be found [here](https://cwiki.apache.org/confluence/display/TIKA/Migrating+to+Tika+2.0.0#MigratingtoTika2.0.0-Metadata) 

Note 1: Anyone concerned about log4j's CVE-2021-44228, Tika 2.2.0 includes log4j 2.15.0 (which disables JndiLookup)

Note 2: The updated Tika will by default log an INFO message about the performance impact of the TesseractOCR library. I have made Henkei v2.x behave the same as v1.x by making the loading of the OCR library opt in. 

I've tried to disable the INFO message by specifying a Log4j configuration file (see below), however my knowledge of Log4j is limited, and in specifying the config file it appears to disable logging of any message. I don't think that is a good option as it would mute any "real" errors. I tried enabling log4j debugging which showed that the config was loading successfully, but still no output. Any input on how to do this "properly" would be appreciated! 

```
java -Dlog4j.configurationFile=path/to/log4j-config.xml -Dlog4j2.debug=true -jar path/to/tika-app.jar .... etc etc ....
```
