### PR TITLE
Version bump to v2.3.0.1

### DIFF
--- a/lib/henkei.rb
+++ b/lib/henkei.rb
@@ -25,7 +25,7 @@ require 'open3'
 # Read text and metadata from files and documents using Apache Tika toolkit
 class Henkei # rubocop:disable Metrics/ClassLength
   GEM_PATH = File.dirname(File.dirname(__FILE__))
-  JAR_PATH = File.join(Henkei::GEM_PATH, 'jar', 'tika-app-2.2.1.jar')
+  JAR_PATH = File.join(Henkei::GEM_PATH, 'jar', 'tika-app-2.3.0.jar')
   CONFIG_PATH = File.join(Henkei::GEM_PATH, 'jar', 'tika-config.xml')
   CONFIG_WITHOUT_OCR_PATH = File.join(Henkei::GEM_PATH, 'jar', 'tika-config-without-ocr.xml')
 

--- a/lib/henkei/version.rb
+++ b/lib/henkei/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Henkei
-  VERSION = '2.2.1.2'
+  VERSION = '2.3.0.1'
 end


### PR DESCRIPTION
Update Tika to v2.3.0

This includes:
* an upgrade of log4j2 to v2.17.1
* non-trivial upgrade of Apache POI which will result in significantly more logging output. 

The additional POI log output appears to be in the form of an error dump related to:
```
org.apache.poi.util.XMLHelper SAX Feature unsupported
```
I haven't been able to find a solution for this, however the log4j upgrade may outweigh the additional logging?