### PR TITLE
Version bump to v1.28.1.1

### DIFF
--- a/lib/henkei.rb
+++ b/lib/henkei.rb
@@ -25,7 +25,7 @@ require 'open3'
 # Read text and metadata from files and documents using Apache Tika toolkit
 class Henkei # rubocop:disable Metrics/ClassLength
   GEM_PATH = File.dirname(File.dirname(__FILE__))
-  JAR_PATH = File.join(Henkei::GEM_PATH, 'jar', 'tika-app-1.28.jar')
+  JAR_PATH = File.join(Henkei::GEM_PATH, 'jar', 'tika-app-1.28.1.jar')
   CONFIG_PATH = File.join(Henkei::GEM_PATH, 'jar', 'tika-config.xml')
   DEFAULT_SERVER_PORT = 9293 # an arbitrary, but perfectly cromulent, port
 

--- a/lib/henkei/version.rb
+++ b/lib/henkei/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Henkei
-  VERSION = '1.28.1'
+  VERSION = '1.28.1.1'
 end


### PR DESCRIPTION
Update Tika to v1.28.1
see https://tika.apache.org/1.28.1/index.html

Security upgrades: xerces, log4j2, junrar and protobuf (TIKA-3671 and TIKA-3638).
General dependency upgrades (TIKA-3671).