### PR TITLE
Version bump to v2.9.2.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3']
+        ruby-version: ['3.0', '3.1', '3.2', '3.3']
 
     steps:
       - uses: actions/checkout@v3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
 
 Layout/EmptyLinesAroundAttributeAccessor:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gemspec
 group :development do
   gem 'bundler', '~> 2.0'
   gem 'nokogiri', '~> 1.12'
-  gem 'rails', '~> 5.0'
   gem 'rake', '~> 12.3'
   gem 'rspec', '~> 3.7'
   gem 'rubocop', '~> 1.26'

--- a/henkei.gemspec
+++ b/henkei.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
                        '(.doc, .docx, .pages, .odt, .rtf, .pdf) using Apache Tika toolkit'
   spec.homepage      = 'https://github.com/abrom/henkei'
   spec.license       = 'MIT'
-  spec.required_ruby_version = ['>= 2.7.0', '< 3.4.0']
+  spec.required_ruby_version = ['>= 3.0.0', '< 3.4.0']
 
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
   # delete this section to allow pushing this gem to any host.

--- a/lib/henkei.rb
+++ b/lib/henkei.rb
@@ -25,7 +25,7 @@ require 'open3'
 # Read text and metadata from files and documents using Apache Tika toolkit
 class Henkei # rubocop:disable Metrics/ClassLength
   GEM_PATH = File.dirname(File.dirname(__FILE__))
-  JAR_PATH = File.join(Henkei::GEM_PATH, 'jar', 'tika-app-2.9.1.jar')
+  JAR_PATH = File.join(Henkei::GEM_PATH, 'jar', 'tika-app-2.9.2.jar')
   CONFIG_PATH = File.join(Henkei::GEM_PATH, 'jar', 'tika-config.xml')
   CONFIG_WITHOUT_OCR_PATH = File.join(Henkei::GEM_PATH, 'jar', 'tika-config-without-ocr.xml')
 

--- a/lib/henkei/version.rb
+++ b/lib/henkei/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Henkei
-  VERSION = '2.9.1.1'
+  VERSION = '2.9.2.1'
 end


### PR DESCRIPTION
Update Tika to v2.9.2
see https://tika.apache.org/2.9.2/index.html