### PR TITLE
Version bump to v3.3.0.1

### DIFF
--- a/lib/henkei.rb
+++ b/lib/henkei.rb
@@ -25,7 +25,7 @@ require 'open3'
 # Read text and metadata from files and documents using Apache Tika toolkit
 class Henkei # rubocop:disable Metrics/ClassLength
   GEM_PATH = File.dirname(__FILE__, 2)
-  JAR_PATH = File.join(Henkei::GEM_PATH, 'jar', 'tika-app-3.2.3.jar')
+  JAR_PATH = File.join(Henkei::GEM_PATH, 'jar', 'tika-app-3.3.0.jar')
   CONFIG_PATH = File.join(Henkei::GEM_PATH, 'jar', 'tika-config.xml')
   CONFIG_WITHOUT_OCR_PATH = File.join(Henkei::GEM_PATH, 'jar', 'tika-config-without-ocr.xml')
 

--- a/lib/henkei/version.rb
+++ b/lib/henkei/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Henkei
-  VERSION = '3.2.3.2'
+  VERSION = '3.3.0.1'
 end


### PR DESCRIPTION
Update Tika to v3.3.0
see https://tika.apache.org/3.3.0/index.html